### PR TITLE
Fixed javascript rounding function for most edge cases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "0.0.6"
+VERSION = "0.0.7"
 SHORT_DESCRIPTION = "Twitter X-Client-Transaction-Id generator written in python."
 
 with open("requirements.txt") as file:

--- a/x_client_transaction/utils.py
+++ b/x_client_transaction/utils.py
@@ -2,7 +2,7 @@ import re
 import bs4
 import base64
 from typing import Union
-import decimal
+import math
 
 
 def handle_x_migration(session):
@@ -70,11 +70,8 @@ def is_odd(num: Union[int, float]):
         return -1.0
     return 0.0
 
-def js_round(num: Union[int, float], ndigits: int=0):
-    with decimal.localcontext() as ctx:
-        ctx.rounding = decimal.ROUND_HALF_UP
-        dec = decimal.Decimal(num)
-        return float(round(dec, ndigits))
+def js_round(num: Union[int, float]):
+    return math.floor(num + 0.5)
 
 def base64_encode(string):
     string = string.encode() if isinstance(string, str) else string


### PR DESCRIPTION
As mikf mentions in https://github.com/iSarabjitDhiman/XClientTransaction/pull/10#pullrequestreview-2808125709
And also according to the MDN description of javascript's `Math.round()`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round#description
The `js_round` function is now implemented as `math.floor(num + 0.5)`.

This is mainly in the case the function is re-used in the future to round negative numbers, or numbers close to 0, so not a huge priority.