### PR TITLE
Fix more Javascript-style rounding edge cases

### DIFF
--- a/x_client_transaction/utils.py
+++ b/x_client_transaction/utils.py
@@ -11,10 +11,9 @@ class Math:
     def round(num):
         # using javascript...? just use the native Math.round(num)
         x = math.floor(num)
-        if (num - x) < 0.5:
-            return x
-        else:
-            return math.ceil(num)
+        if (num - x) >= 0.5:
+            x = math.ceil(num)
+        return math.copysign(x, num)
 
 
 def handle_x_migration(session):

--- a/x_client_transaction/utils.py
+++ b/x_client_transaction/utils.py
@@ -10,9 +10,11 @@ class Math:
     @staticmethod
     def round(num):
         # using javascript...? just use the native Math.round(num)
-        if num == -0 or -0.5 <= num < 0:
-            return -0.0
-        return math.floor(num + 0.5)
+        x = math.floor(num)
+        if (num - x) < 0.5:
+            return x
+        else:
+            return math.ceil(num)
 
 
 def handle_x_migration(session):


### PR DESCRIPTION
(Source of function is originally from [Stack Overflow](https://stackoverflow.com/a/34876996), then I reworked it so that zeros would maintain their sign.)

There were some cases where the results of the current rounding function still differed from that of Javascript.

As our baseline...
```javascript
tests = [
    -0.0,
    0.0,
    -0.5,
    0.5,
    -0.9,
    1.5,
    -1.5,
    -5.05,
    -5.5,
    -5.95,
    -4.95,
    -4.5,
    -4.05,
    3.95,
    3.5,
    3.05,
    4.95,
    4.5,
    4.05,
    5.95,
    5.5,
    5.05,
    0.49999999999999994,
    5000000000000001.0,
    -0.3,
];
tests.map(Math.round);
```
results in
```
0: -0​
1: 0​
2: -0​
3: 1​
4: -1​
5: 2​
6: -1​
7: -5​
8: -5​
9: -6​
10: -5​
11: -4​
12: -4​
13: 4​
14: 4​
15: 3​
16: 5
17: 5
18: 4
19: 6
20: 6
21: 5
22: 0
23: 5000000000000001
24: -0
```


For our Python test:
```python
import math

def current_round(num):
    if num == -0 or -0.5 <= num < 0:
        return -0.0
    return math.floor(num + 0.5)

def new_round(num):
    x = math.floor(num)
    if (num - x) >= 0.5:
        x = math.ceil(num)
    return math.copysign(x, num)

tests = [
    -0.0,
    0.0,
    -0.5,
    0.5,
    -0.9,
    1.5,
    -1.5,
    -5.05,
    -5.5,
    -5.95,
    -4.95,
    -4.5,
    -4.05,
    3.95,
    3.5,
    3.05,
    4.95,
    4.5,
    4.05,
    5.95,
    5.5,
    5.05,
    0.49999999999999994,
    5000000000000001.0,
    -0.3,
]

print("CURRENT")
for i, n in enumerate(tests):
    print(f"{i}: {current_round(n)}")

print("NEW")
for i, n in enumerate(tests):
    print(f"{i}: {new_round(n)}")
```
Results, with differences to the Javascript baseline highlighted:
```
CURRENT
0: -0.0
1: -0.0 (should be 0)
2: -0.0
3: 1
4: -1
5: 2
6: -1
7: -5
8: -5
9: -6
10: -5
11: -4
12: -4
13: 4
14: 4
15: 3
16: 5
17: 5
18: 4
19: 6
20: 6
21: 5
22: 1 (should be 0)
23: 5000000000000002 (should be 5000000000000001)
24: -0.0
NEW
0: -0.0
1: 0.0
2: -0.0
3: 1.0
4: -1.0
5: 2.0
6: -1.0
7: -5.0
8: -5.0
9: -6.0
10: -5.0
11: -4.0
12: -4.0
13: 4.0
14: 4.0
15: 3.0
16: 5.0
17: 5.0
18: 4.0
19: 6.0
20: 6.0
21: 5.0
22: 0.0
23: 5000000000000001.0
24: -0.0
```

Cases 1, 22, and 23 are now correct.

(As an aside, I ran into an annoyance with JS while testing: ```console.log(Math.round(-0.0))``` gives `-0`,  while ```console.log(`${Math.round(-0.0)}`)``` gives `0`, at least in Firefox)
