### PR TITLE
fix: graceful error when ondemand.s file not found (X homepage redesign)

### DIFF
--- a/x_client_transaction/utils.py
+++ b/x_client_transaction/utils.py
@@ -56,9 +56,23 @@ def get_migration_form(response: bs4.BeautifulSoup):
 
 
 def get_ondemand_file_url(response: bs4.BeautifulSoup):
-    on_demand_file_index = ON_DEMAND_FILE_REGEX.search(str(response)).group(1)
+    match = ON_DEMAND_FILE_REGEX.search(str(response))
+    if not match:
+        raise ValueError(
+            "Could not find ondemand.s file reference in the response. "
+            "X may have changed its frontend structure. "
+            "Try using the search page (https://x.com/search?q=AI&f=live) "
+            "instead of the homepage, as it still uses the legacy frontend."
+        )
+    on_demand_file_index = match.group(1)
     regex = re.compile(ON_DEMAND_HASH_PATTERN.format(on_demand_file_index))
-    filename = regex.search(str(response)).group(1)
+    file_match = regex.search(str(response))
+    if not file_match:
+        raise ValueError(
+            f"Found ondemand.s index ({on_demand_file_index}) but could not extract the file hash. "
+            "The HTML structure may have changed."
+        )
+    filename = file_match.group(1)
     return ON_DEMAND_FILE_URL.format(filename=filename)
 
 


### PR DESCRIPTION
## Problem

X recently redesigned its homepage (`x.com`) to use a new React Router (TSR) architecture. The new homepage no longer includes the `ondemand.s` file reference in its HTML, which causes `ON_DEMAND_FILE_REGEX.search()` to return `None`. Calling `.group(1)` on `None` then raises:

```
NoneType object has no attribute group
```

This affects all users who fetch the homepage to initialize `ClientTransaction`.

Related issues: #41, #42, #43

## Solution

Instead of crashing with an unhelpful `AttributeError`, this PR:
- Checks if the regex match succeeds before calling `.group()`
- Raises a descriptive `ValueError` with troubleshooting guidance
- Documents that the **search page** (`https://x.com/search?q=AI&f=live`) still uses the legacy frontend and contains the `ondemand.s` file reference

## Testing

```python
# Before (crashes):
home_page = session.get("https://x.com")
soup = BeautifulSoup(home_page.content, "html.parser")
url = get_ondemand_file_url(soup)  # AttributeError: NoneType has no attribute group

# After (clear error):
url = get_ondemand_file_url(soup)
# ValueError: Could not find ondemand.s file reference in the response.
# X may have changed its frontend structure.
# Try using the search page (https://x.com/search?q=AI&f=live) instead.

# Workaround (works on both old and new X):
search_page = session.get("https://x.com/search?q=AI&f=live")
soup = BeautifulSoup(search_page.content, "html.parser")
url = get_ondemand_file_url(soup)  # Works! Search page has ondemand.s
```

## Notes

The search page (`x.com/search`) has NOT been redesigned and still uses the `responsive-web/client-web/` path with the `ondemand.s` file. Users can use it as a fallback when the homepage does not contain the file.