### PR TITLE
feat: add fetch_home_page() helper with search page fallback

### DIFF
--- a/x_client_transaction/utils.py
+++ b/x_client_transaction/utils.py
@@ -62,6 +62,43 @@ def get_ondemand_file_url(response: bs4.BeautifulSoup):
     return ON_DEMAND_FILE_URL.format(filename=filename)
 
 
+def fetch_home_page(session, url: str = "https://x.com/home"):
+    """Fetch a page and return it as BeautifulSoup.
+
+    X redesigned its homepage to use a new React Router (TSR) architecture.
+    The new homepage no longer contains the ondemand.s file reference.
+    However, the search page (https://x.com/search?q=AI&f=live) still uses
+    the legacy frontend and contains the ondemand.s file.
+
+    This helper tries the given URL first, and if ondemand.s is not found,
+    falls back to the search page.
+
+    Args:
+        session: A requests.Session or curl_cffi Session with headers set.
+        url: URL to fetch. Defaults to the homepage.
+
+    Returns:
+        bs4.BeautifulSoup: The page response that contains the ondemand.s
+        file reference (either from the given URL or the search page fallback).
+    """
+    response = session.get(url=url)
+    home_page = bs4.BeautifulSoup(response.content, 'html.parser')
+
+    # Check if ondemand.s is present
+    if ON_DEMAND_FILE_REGEX.search(str(home_page)):
+        return home_page
+
+    # Fallback: use the search page which still has the legacy frontend
+    search_url = "https://x.com/search?q=AI&f=live"
+    search_response = session.get(url=search_url)
+    search_page = bs4.BeautifulSoup(search_response.content, 'html.parser')
+
+    if ON_DEMAND_FILE_REGEX.search(str(search_page)):
+        return search_page
+
+    return home_page  # Return original even if ondemand.s not found
+
+
 def handle_x_migration(session):
     # for python requests -> session = requests.Session()
     # session.headers = generate_headers()


### PR DESCRIPTION
## Problem

X recently redesigned its homepage (`x.com`) to use a new React Router (TSR) architecture. The new homepage no longer includes the `ondemand.s` file reference in its HTML. This breaks `ClientTransaction` initialization for all users who fetch the homepage.

However, **the search page** (`https://x.com/search?q=AI&f=live`) has NOT been redesigned — it still uses the legacy `responsive-web/client-web/` frontend and contains the `ondemand.s` file.

Related issues: #41, #42, #43

## Solution

This PR adds a `fetch_home_page()` helper function that:

1. Tries the given URL first (defaults to homepage)
2. Checks if `ondemand.s` is present in the response
3. If not found, automatically falls back to the search page
4. Returns the `BeautifulSoup` object that contains the `ondemand.s` file reference

## Usage

```python
from x_client_transaction.utils import fetch_home_page, get_ondemand_file_url

session = requests.Session()
session.headers = generate_headers()

# Before (breaks on new X homepage):
home_page = bs4.BeautifulSoup(session.get("https://x.com/home").content, "html.parser")
ondemand_url = get_ondemand_file_url(home_page)  # AttributeError!

# After (works on both old and new X):
home_page = fetch_home_page(session)  # Auto-fallback to search page
ondemand_url = get_ondemand_file_url(home_page)  # Works!
```

## Non-breaking

This is a purely additive change — no existing functions are modified. The existing `get_ondemand_file_url()` API is unchanged.

## Testing

Verified that `https://x.com/search?q=AI&f=live` returns HTML containing 232 `ondemand` references and the `ON_DEMAND_FILE_REGEX` matches correctly, producing a valid `ondemand.s` URL (`ondemand.s.0a828d2a.js`).